### PR TITLE
Task/45 appmodule support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,10 @@ const initialize = ({
 
 export default initialize;
 
+// expose initialize to window for AppModule integration
+window.DrugDictionaryApp = initialize;
+
+
 // The following lets us run the app in dev not in situ as would normally be the case.
 const appParams = window.APP_PARAMS || {};
 const integrationTestOverrides = window.INT_TEST_APP_PARAMS || {};


### PR DESCRIPTION
Closes #45 

Exposing the app initialization to the window for the new generic AppModules integration scheme

Initialization of the app now accessed via `window.DrugDictionaryApp()`

Generic AppModules Support
https://github.com/NCIOCPL/cgov-digital-platform/pull/2931