### PR TITLE
Bugfix: Clicking term causes page refresh

### DIFF
--- a/src/components/molecules/TermList/__tests__/term-list-test.js
+++ b/src/components/molecules/TermList/__tests__/term-list-test.js
@@ -1,7 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 
 import TermList from '../term-list';
+import { useStateValue } from '../../../../store/store';
+
+jest.mock('../../../../store/store.js');
+
+useStateValue.mockReturnValue([
+	{
+		basePath: '/',
+	},
+]);
 
 describe('<TermList />', () => {
 	const props = {
@@ -97,7 +107,9 @@ describe('<TermList />', () => {
 	};
 	test.only('should show term list page title with result count', () => {
 		render(
-			<TermList {...props} />
+      <MemoryRouter initialEntries={['/']}>
+        <TermList {...props} />
+      </MemoryRouter>
 		);
 
 		expect(screen.getByText('3 results found for: A')).toBeInTheDocument();

--- a/src/components/molecules/TermList/term-list.jsx
+++ b/src/components/molecules/TermList/term-list.jsx
@@ -2,22 +2,25 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import TermListItem from '../TermListItem';
+import { useAppPaths } from '../../../hooks';
 
 const TermList = ({
 	searchTerm,
-	termLinkPath,
 	termLinkTrackingHandler,
 	terms,
 	totalTermCount,
 }) => {
+  const { DefinitionPath } = useAppPaths();
+
 	return (
 		<>
 			<h4> {`${totalTermCount} results found for: ${searchTerm}`} </h4>
 			<dl>
 				{terms.map((term, index) => {
+          const idOrName = term.prettyUrlName ? term.prettyUrlName : term.termId;
 					return (
 						<TermListItem
-							itemIndex={index+1}
+							itemIndex={index + 1}
 							key={index}
 							preferredName={term.preferredName}
 							prettyUrlName={term.prettyUrlName}
@@ -25,7 +28,7 @@ const TermList = ({
 							termDefinition={term?.definition?.html}
 							termId={term.termId}
 							termLinkTrackingHandler={termLinkTrackingHandler}
-							termLinkPath={termLinkPath}
+							termLinkPath={DefinitionPath({ idOrName })}
 						/>
 					);
 				})}
@@ -36,7 +39,6 @@ const TermList = ({
 
 TermList.propTypes = {
 	searchTerm: PropTypes.string.isRequired,
-	termLinkPath: PropTypes.any.isRequired,
 	termLinkTrackingHandler: PropTypes.func,
 	terms: PropTypes.arrayOf(PropTypes.shape({
 		aliases: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/molecules/TermListItem/__tests__/term-list-item.test.js
+++ b/src/components/molecules/TermListItem/__tests__/term-list-item.test.js
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 
 import TermListItem from '../term-list-item';
 
@@ -11,17 +12,19 @@ describe('<TermListItem />', () => {
 		const termDefinition =
 			'An orally bioavailable protein tyrosine kinase inhibitor of mutated forms of the tumor-associated antigen mast/stem cell factor receptor c-Kit (SCFR), with potential antineoplastic activity. Upon oral administration, c-Kit inhibitor PLX9486 binds to and inhibits specific c-Kit mutants. This may result in an inhibition of tumor cell proliferation in cancer cell types that overexpress these c-Kit mutations. c-Kit, a transmembrane protein and receptor tyrosine kinase, is overexpressed in solid tumors and hematological malignancies; it plays a key role in the regulation of cell differentiation and proliferation.';
 		const termId = 770823;
-		const termLinkPath = jest.fn(({ idOrName }) => `/def/${idOrName}`);
+		const termLinkPath = '/def/c-kit-inhibitor-plx9486';
 
 		const { container } = render(
-			<TermListItem
-				itemIndex={itemIndex}
-				prettyUrlName={prettyUrlName}
-				term={term}
-				termDefinition={termDefinition}
-				termId={termId}
-				termLinkPath={termLinkPath}
-			/>
+			<MemoryRouter initialEntries={['/']}>
+				<TermListItem
+					itemIndex={itemIndex}
+					prettyUrlName={prettyUrlName}
+					term={term}
+					termDefinition={termDefinition}
+					termId={termId}
+					termLinkPath={termLinkPath}
+				/>
+			</MemoryRouter>
 		);
 
 		expect(screen.getByText('c-Kit inhibitor PLX9486')).toBeInTheDocument();
@@ -42,16 +45,18 @@ describe('<TermListItem />', () => {
 		const termDefinition =
 			'An orally bioavailable protein tyrosine kinase inhibitor of mutated forms of the tumor-associated antigen mast/stem cell factor receptor c-Kit (SCFR), with potential antineoplastic activity. Upon oral administration, c-Kit inhibitor PLX9486 binds to and inhibits specific c-Kit mutants. This may result in an inhibition of tumor cell proliferation in cancer cell types that overexpress these c-Kit mutations. c-Kit, a transmembrane protein and receptor tyrosine kinase, is overexpressed in solid tumors and hematological malignancies; it plays a key role in the regulation of cell differentiation and proliferation.';
 		const termId = 770823;
-		const termLinkPath = jest.fn(({ idOrName }) => `/def/${idOrName}`);
+		const termLinkPath = '/def/770823';
 		console.error = jest.fn();
 		const { container } = render(
-			<TermListItem
-				itemIndex={itemIndex}
-				term={term}
-				termDefinition={termDefinition}
-				termId={termId}
-				termLinkPath={termLinkPath}
-			/>
+			<MemoryRouter initialEntries={['/']}>
+				<TermListItem
+					itemIndex={itemIndex}
+					term={term}
+					termDefinition={termDefinition}
+					termId={termId}
+					termLinkPath={termLinkPath}
+				/>
+			</MemoryRouter>
 		);
 		fireEvent.click(screen.getByRole('link'));
 		expect(container.querySelector('a')).toHaveAttribute('href', '/def/770823');
@@ -63,11 +68,15 @@ describe('<TermListItem />', () => {
 			preferredName: 'etaracizumab',
 			term: 'Abegrin',
 			termId: 38491,
-			termLinkPath: jest.fn(({ idOrName }) => `/def/${idOrName}`),
+			termLinkPath: '/def/etaracizumab',
 			prettyUrlName: 'etaracizumab',
 		};
 
-		render(<TermListItem {...props} />);
+		render(
+			<MemoryRouter initialEntries={['/']}>
+				<TermListItem {...props} />
+			</MemoryRouter>
+		);
 		expect(
 			screen.getByText('(Other name for: etaracizumab)')
 		).toBeInTheDocument();
@@ -80,19 +89,21 @@ describe('<TermListItem />', () => {
 		const termDefinition =
 			'An orally bioavailable protein tyrosine kinase inhibitor of mutated forms of the tumor-associated antigen mast/stem cell factor receptor c-Kit (SCFR), with potential antineoplastic activity. Upon oral administration, c-Kit inhibitor PLX9486 binds to and inhibits specific c-Kit mutants. This may result in an inhibition of tumor cell proliferation in cancer cell types that overexpress these c-Kit mutations. c-Kit, a transmembrane protein and receptor tyrosine kinase, is overexpressed in solid tumors and hematological malignancies; it plays a key role in the regulation of cell differentiation and proliferation.';
 		const termId = 770823;
-		const termLinkPath = jest.fn(({ idOrName }) => `/def/${idOrName}`);
+		const termLinkPath = '/def/c-kit-inhibitor-plx9486';
 		const termLinkTrackingHandler = jest.fn();
 		console.error = jest.fn();
 		render(
-			<TermListItem
-				itemIndex={itemIndex}
-				prettyUrlName={prettyUrlName}
-				term={term}
-				termDefinition={termDefinition}
-				termId={termId}
-				termLinkTrackingHandler={termLinkTrackingHandler}
-				termLinkPath={termLinkPath}
-			/>
+			<MemoryRouter initialEntries={['/']}>
+				<TermListItem
+					itemIndex={itemIndex}
+					prettyUrlName={prettyUrlName}
+					term={term}
+					termDefinition={termDefinition}
+					termId={termId}
+					termLinkTrackingHandler={termLinkTrackingHandler}
+					termLinkPath={termLinkPath}
+				/>
+			</MemoryRouter>
 		);
 		const termLink = screen.getByRole('link');
 		expect(termLink.textContent).toBe('c-Kit inhibitor PLX9486');

--- a/src/components/molecules/TermListItem/term-list-item.jsx
+++ b/src/components/molecules/TermListItem/term-list-item.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 import './term-list-item.scss';
 
 const TermListItem = ({
@@ -28,9 +30,11 @@ const TermListItem = ({
 		<>
 			<dt>
 				<dfn data-cdr-id={termId}>
-					<a href={termLinkPath({ idOrName })} onClick={termLinkClickHandler}>
+					<Link
+						to={termLinkPath}
+						onClick={termLinkClickHandler}>
 						{term}
-					</a>
+					</Link>
 				</dfn>
 			</dt>
 			<dd dangerouslySetInnerHTML={{ __html: definitionText }}></dd>
@@ -45,7 +49,7 @@ TermListItem.propTypes = {
 	term: PropTypes.string.isRequired,
 	termDefinition: PropTypes.string,
 	termId: PropTypes.number.isRequired,
-	termLinkPath: PropTypes.any.isRequired,
+	termLinkPath: PropTypes.string.isRequired,
 	termLinkTrackingHandler: PropTypes.func,
 };
 


### PR DESCRIPTION
Closes #53 .

Swapped out <a> tags with <Link > so that the entire page doesn't refresh when clicking a term and transitioning to a definition page.