### PR TITLE
(#150) Add meta tags to support prerendering

### DIFF
--- a/cypress/e2e/PageNotFound.feature
+++ b/cypress/e2e/PageNotFound.feature
@@ -8,4 +8,6 @@ Feature: As a user, if I visit the definition page with a pretty url name that d
     And the link "cancer type" to "https://www.cancer.gov/types" appears on the page
     And the link "Get in touch" to "https://www.cancer.gov/contact" appears on the page
     And the search bar appear below
-    
+		And the page contains meta tags with the following names
+			| name                  | content |
+			| prerender-status-code | 404     |

--- a/cypress/e2e/PrettyUrlRedirect.feature
+++ b/cypress/e2e/PrettyUrlRedirect.feature
@@ -4,3 +4,7 @@ Feature: As the website, I should redirect CDR IDs in URLs to its counterpart pr
         Given the user navigates to "/def/750633"
         Then the system redirects user to "/def/acenocoumarol"
         And the system appends "?redirect=true" to the URL
+				And the page contains meta tags with the following names
+					| name                  | content 																					|
+					| prerender-status-code | 301     																					|
+					| prerender-header 			| Location: http://localhost:3000/def/acenocoumarol	|

--- a/src/views/Definition/Definition.jsx
+++ b/src/views/Definition/Definition.jsx
@@ -72,12 +72,30 @@ const Definition = () => {
 		}
 	}, [queryResponse, setDrugDefinition]);
 
+	const preRenderHandler = () => {
+		const preRenderObj = {};
+
+		if (location.search === '?redirect=true') {
+			preRenderObj.statusCode = (
+				<meta name="prerender-status-code" content="301" />
+			);
+			preRenderObj.headerLocation = (
+				<meta
+					name="prerender-header"
+					content={'Location: ' + baseHost + window.location.pathname}
+				/>
+			);
+		}
+
+		return preRenderObj;
+	};
+
 	/**
 	 * Helper function to render metadata.
 	 */
 	const renderHelmet = () => {
 		// Home is indexable, expand and search are not.
-
+		const preRender = preRenderHandler();
 		return (
 			<Helmet>
 				<title>{`Definition of ${drugDefinition.payload.name} - ${dictionaryTitle} - ${siteName}`}</title>
@@ -104,9 +122,12 @@ const Definition = () => {
 						})
 					}
 				/>
+				{preRender.statusCode}
+				{preRender.headerLocation}
 			</Helmet>
 		);
 	};
+
 	return (
 		<>
 			{drugDefinitionLoaded && drugDefinition && (

--- a/src/views/ErrorBoundary/ErrorPage.jsx
+++ b/src/views/ErrorBoundary/ErrorPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import { useTracking } from 'react-tracking';
 
 import { useStateValue } from '../../store/store';
@@ -21,10 +22,24 @@ const ErrorPage = () => {
 		});
 	}, []);
 
+	const renderHelmet = () => {
+		return (
+			<Helmet>
+				<title>Errors Occurred</title>
+				<meta property="dcterms.subject" content="Error Pages" />
+				<meta property="dcterms.type" content="errorpage" />
+				<meta name="prerender-status-code" content="500" />
+			</Helmet>
+		);
+	};
+
 	return (
-		<div className="error-container">
-			<h1>{i18n.errorPageText[language]}</h1>
-		</div>
+		<>
+			{renderHelmet()}
+			<div className="error-container">
+				<h1>{i18n.errorPageText[language]}</h1>
+			</div>
+		</>
 	);
 };
 

--- a/src/views/ErrorBoundary/PageNotFound.jsx
+++ b/src/views/ErrorBoundary/PageNotFound.jsx
@@ -73,6 +73,7 @@ const PageNotFound = () => {
 				<title>{i18n.pageNotFoundTitle[language]}</title>
 				<meta property="dcterms.subject" content="Error Pages" />
 				<meta property="dcterms.type" content="errorpage" />
+				<meta name="prerender-status-code" content="404" />
 			</Helmet>
 		);
 	};


### PR DESCRIPTION
Closes #150 

* Added meta tags to support pre-rendering for Definition, and ErrorPage
* Updated e2e tests with checks for pre-render tags